### PR TITLE
Feat/be datelog refactor

### DIFF
--- a/backend/src/main/java/com/ssafy/lovesol/domain/datelog/controller/DateLogController.java
+++ b/backend/src/main/java/com/ssafy/lovesol/domain/datelog/controller/DateLogController.java
@@ -60,9 +60,8 @@ public class DateLogController {
      */
     @GetMapping("/{dateLogId}")
     public ResponseResult getDateLog(@PathVariable String dateLogId) throws Exception {
-        log.info(dateLogId + " 데이트 기록을 조회합니다.");
+        log.info(dateLogId + " 데이트 일기를 조회합니다.");
         return new SingleResponseResult<DateLog>(dateLogService.getDateLog(Long.parseLong(dateLogId)));
-
     }
 
   
@@ -76,7 +75,7 @@ public class DateLogController {
      */
     @PostMapping("/{dateLogId}")
     public ResponseResult registImage(@PathVariable String dateLogId, @Valid @RequestBody Image image) throws Exception {
-        log.info(dateLogId + " 데이트 로그에 이미지를 삽입합니다.");
+        log.info(dateLogId + " 데이트 일기에 이미지를 삽입합니다.");
         // 데이트 로그에 이미지를 삽입한다.
         dateLogService.insertImage(Long.parseLong(dateLogId), image);
         // TODO: 일기 작성 알림을 보낸다.
@@ -93,6 +92,7 @@ public class DateLogController {
      */
     @GetMapping("/{imageId}")
     public  ResponseResult getImageDetail(@PathVariable String imageId) throws Exception {
+        log.info(imageId + " 이미지를 상세 조회합니다.");
         // 이미지 객체 정보를 조회한다.
         return new SingleResponseResult<Image>(imageService.getImage(Long.parseLong(imageId)));
     }
@@ -107,14 +107,22 @@ public class DateLogController {
      */
     @PutMapping("/{imageId}")
     public ResponseResult modifyImage(@PathVariable String imageId, @Valid @RequestBody UpdateImageDto updateImage) throws Exception {
+        log.info(imageId + " 이미지를 수정합니다.");
         // 이미지 객체를 수정한다.
         imageService.updateImage(updateImage);
         // TODO: 이미지 수정 알림을 보낸다.
         return ResponseResult.failResponse;
     }
 
+    /**
+     * 이미지를 삭제합니다.
+     * @param imageId
+     * @return
+     * @throws Exception
+     */
     @DeleteMapping("/{imageId}")
     public ResponseResult removeImage(@PathVariable String imageId) throws Exception {
+        log.info(imageId + " 이미지를 삭제합니다.");
         // 이미지 객체를 삭제한다.
         imageService.deleteImage(Long.parseLong(imageId));
         return ResponseResult.successResponse;

--- a/backend/src/main/java/com/ssafy/lovesol/domain/datelog/controller/DateLogController.java
+++ b/backend/src/main/java/com/ssafy/lovesol/domain/datelog/controller/DateLogController.java
@@ -1,6 +1,7 @@
 package com.ssafy.lovesol.domain.datelog.controller;
 
 import com.ssafy.lovesol.domain.couple.entity.Couple;
+import com.ssafy.lovesol.domain.datelog.dto.request.InsertImageDto;
 import com.ssafy.lovesol.domain.datelog.dto.request.UpdateImageDto;
 import com.ssafy.lovesol.domain.datelog.entity.DateLog;
 import com.ssafy.lovesol.domain.datelog.entity.Image;
@@ -70,14 +71,14 @@ public class DateLogController {
      * 해당 데이트 일기에 이미지를 첨부한다.
      * 이미지 객체에는 이미지 URL과 이미지의 텍스트 내용이 존재한다.
      * @param dateLogId
-     * @param image
+     * @param insertImage
      * @return
      */
     @PostMapping("/{dateLogId}")
-    public ResponseResult registImage(@PathVariable String dateLogId, @Valid @RequestBody Image image) throws Exception {
+    public ResponseResult registImage(@PathVariable String dateLogId, @Valid @RequestBody InsertImageDto insertImage) throws Exception {
         log.info(dateLogId + " 데이트 일기에 이미지를 삽입합니다.");
         // 데이트 로그에 이미지를 삽입한다.
-        dateLogService.insertImage(Long.parseLong(dateLogId), image);
+        dateLogService.insertImage(Long.parseLong(dateLogId), insertImage);
         // TODO: 일기 작성 알림을 보낸다.
 
         return ResponseResult.successResponse;

--- a/backend/src/main/java/com/ssafy/lovesol/domain/datelog/dto/request/InsertImageDto.java
+++ b/backend/src/main/java/com/ssafy/lovesol/domain/datelog/dto/request/InsertImageDto.java
@@ -1,21 +1,19 @@
 package com.ssafy.lovesol.domain.datelog.dto.request;
 
 import com.ssafy.lovesol.domain.datelog.entity.Image;
-import com.ssafy.lovesol.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Schema(description = "이미지 변경 요청 DTO")
-public class UpdateImageDto {
-
-    @NotBlank
-    @Schema(description = "이미지 ID")
-    private Long imageId;
+@Schema(description = "이미지 삽입 요청 DTO")
+public class InsertImageDto {
     @NotBlank
     @Schema(description = "이미지 URL")
     private String imgUrl;
@@ -26,7 +24,6 @@ public class UpdateImageDto {
 
     public Image toEntity(){
         return Image.builder()
-                .imageId(imageId)
                 .imgUrl(imgUrl)
                 .content(content)
                 .build();

--- a/backend/src/main/java/com/ssafy/lovesol/domain/datelog/entity/DateLog.java
+++ b/backend/src/main/java/com/ssafy/lovesol/domain/datelog/entity/DateLog.java
@@ -35,6 +35,10 @@ public class DateLog {
     @OneToMany(mappedBy = "dateLog", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> imageList;
 
+    public void accumulateMileage(int mileage) {
+        this.mileage += mileage;
+    }
+
     public static DateLog create(Couple couple, LocalDateTime dateAt){
         return DateLog.builder()
                 .couple(couple)

--- a/backend/src/main/java/com/ssafy/lovesol/domain/datelog/entity/DateLog.java
+++ b/backend/src/main/java/com/ssafy/lovesol/domain/datelog/entity/DateLog.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 @Builder
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
@@ -35,4 +34,11 @@ public class DateLog {
 
     @OneToMany(mappedBy = "dateLog", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> imageList;
+
+    public static DateLog create(Couple couple, LocalDateTime dateAt){
+        return DateLog.builder()
+                .couple(couple)
+                .dateAt(dateAt)
+                .build();
+    }
 }

--- a/backend/src/main/java/com/ssafy/lovesol/domain/datelog/entity/Image.java
+++ b/backend/src/main/java/com/ssafy/lovesol/domain/datelog/entity/Image.java
@@ -1,5 +1,6 @@
 package com.ssafy.lovesol.domain.datelog.entity;
 
+import com.ssafy.lovesol.domain.couple.entity.Couple;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -40,6 +41,15 @@ public class Image{
 
     public void updateContent(String content) {
         this.content = content;
+    }
+
+    public static Image create(DateLog dateLog, String imgUrl, String content, LocalDateTime createAt){
+        return Image.builder()
+                .dateLog(dateLog)
+                .imgUrl(imgUrl)
+                .content(content)
+                .createAt(createAt)
+                .build();
     }
 }
 

--- a/backend/src/main/java/com/ssafy/lovesol/domain/datelog/service/DateLogService.java
+++ b/backend/src/main/java/com/ssafy/lovesol/domain/datelog/service/DateLogService.java
@@ -1,5 +1,6 @@
 package com.ssafy.lovesol.domain.datelog.service;
 
+import com.ssafy.lovesol.domain.datelog.dto.request.InsertImageDto;
 import com.ssafy.lovesol.domain.datelog.entity.DateLog;
 import com.ssafy.lovesol.domain.datelog.entity.Image;
 
@@ -11,5 +12,5 @@ public interface DateLogService {
 
     DateLog getDateLog(Long dateLogId);
 
-    void insertImage(Long dateLogId, Image image);
+    void insertImage(Long dateLogId, InsertImageDto insertImage);
 }

--- a/backend/src/main/java/com/ssafy/lovesol/domain/datelog/service/DateLogServiceImpl.java
+++ b/backend/src/main/java/com/ssafy/lovesol/domain/datelog/service/DateLogServiceImpl.java
@@ -29,10 +29,8 @@ public class DateLogServiceImpl implements DateLogService{
     public Long createDateLog(Long coupleId, LocalDateTime dateAt) {
         // TODO: 커플 not exist 예외 생성하기
         Couple couple = coupleRepository.findById(coupleId).orElseThrow(NotExistDateLogException::new);
-        DateLog dateLog = new DateLog();
         // 커플 객체와 날짜를 dateLog에 삽입한다.
-        dateLog.setCouple(couple);
-        dateLog.setDateAt(dateAt);
+        DateLog dateLog = DateLog.create(couple, dateAt);
         return dateLogRepository.save(dateLog).getDateLogId();
     }
 

--- a/backend/src/main/java/com/ssafy/lovesol/domain/datelog/service/DateLogServiceImpl.java
+++ b/backend/src/main/java/com/ssafy/lovesol/domain/datelog/service/DateLogServiceImpl.java
@@ -5,18 +5,14 @@ import com.ssafy.lovesol.domain.couple.repository.CoupleRepository;
 import com.ssafy.lovesol.domain.datelog.entity.DateLog;
 import com.ssafy.lovesol.domain.datelog.entity.Image;
 import com.ssafy.lovesol.domain.datelog.repository.DateLogRepository;
+import com.ssafy.lovesol.global.exception.NotExistCoupleException;
 import com.ssafy.lovesol.global.exception.NotExistDateLogException;
-import com.ssafy.lovesol.global.response.ResponseResult;
-import com.ssafy.lovesol.global.response.SingleResponseResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PathVariable;
 
 import java.time.LocalDateTime;
-import java.util.Date;
-import java.util.Optional;
 
 
 @Slf4j
@@ -27,8 +23,8 @@ public class DateLogServiceImpl implements DateLogService{
     CoupleRepository coupleRepository;
     @Override
     public Long createDateLog(Long coupleId, LocalDateTime dateAt) {
-        // TODO: 커플 not exist 예외 생성하기
-        Couple couple = coupleRepository.findById(coupleId).orElseThrow(NotExistDateLogException::new);
+        // 커플 정보가 존재하는지 검사한다.
+        Couple couple = coupleRepository.findById(coupleId).orElseThrow(NotExistCoupleException::new);
         // 커플 객체와 날짜를 dateLog에 삽입한다.
         DateLog dateLog = DateLog.create(couple, dateAt);
         return dateLogRepository.save(dateLog).getDateLogId();
@@ -50,7 +46,7 @@ public class DateLogServiceImpl implements DateLogService{
         // 데이트 일기에 이미지를 삽입한다.
         dateLog.getImageList().add(image);
         // 데이트 일기에마일리지(exp)를 적립한다.
-        dateLog.setMileage(dateLog.getMileage() + 10);
+        dateLog.accumulateMileage(10);
         // TODO: 커플에게 마일리지를 적립한다.
     }
 }

--- a/backend/src/main/java/com/ssafy/lovesol/domain/datelog/service/DateLogServiceImpl.java
+++ b/backend/src/main/java/com/ssafy/lovesol/domain/datelog/service/DateLogServiceImpl.java
@@ -2,6 +2,8 @@ package com.ssafy.lovesol.domain.datelog.service;
 
 import com.ssafy.lovesol.domain.couple.entity.Couple;
 import com.ssafy.lovesol.domain.couple.repository.CoupleRepository;
+import com.ssafy.lovesol.domain.couple.repository.PetRepository;
+import com.ssafy.lovesol.domain.datelog.dto.request.InsertImageDto;
 import com.ssafy.lovesol.domain.datelog.entity.DateLog;
 import com.ssafy.lovesol.domain.datelog.entity.Image;
 import com.ssafy.lovesol.domain.datelog.repository.DateLogRepository;
@@ -21,6 +23,7 @@ import java.time.LocalDateTime;
 public class DateLogServiceImpl implements DateLogService{
     DateLogRepository dateLogRepository;
     CoupleRepository coupleRepository;
+    PetRepository petRepository;
     @Override
     public Long createDateLog(Long coupleId, LocalDateTime dateAt) {
         // 커플 정보가 존재하는지 검사한다.
@@ -39,14 +42,17 @@ public class DateLogServiceImpl implements DateLogService{
 
     @Override
     @Transactional
-    public void insertImage(Long dateLogId, Image image) {
+    public void insertImage(Long dateLogId, InsertImageDto insertImage) {
         // 해당 데이트 일기가 존재하는지 검사한다.
         DateLog dateLog = dateLogRepository.findById(dateLogId).orElseThrow(NotExistDateLogException::new);
 
+        // 데이트 로그, 이미지 url, 이미지 내용, 현재 작성된 시간을 가진 이미지 객체 생성
+        Image image = Image.create(dateLog, insertImage.getImgUrl(), insertImage.getContent(), LocalDateTime.now());
         // 데이트 일기에 이미지를 삽입한다.
         dateLog.getImageList().add(image);
         // 데이트 일기에마일리지(exp)를 적립한다.
         dateLog.accumulateMileage(10);
-        // TODO: 커플에게 마일리지를 적립한다.
+        // TODO: 펫에게 마일리지를 적립한다.
+
     }
 }

--- a/backend/src/main/java/com/ssafy/lovesol/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/com/ssafy/lovesol/global/exception/ExceptionCode.java
@@ -13,6 +13,7 @@ public enum ExceptionCode {
 	NOT_EXIST_DATE_LOG(490, "데이트 일기가 존재하지 않습니다."),
 	NOT_EXIST_IMAGE(495, "이미지가 존재하지 않습니다."),
 	NOT_EXIST_ACCOUNT_EXCEPTION(470, "사용자가 존재하지 않습니다."),
+	NOT_EXIST_COUPLE_EXCEPTION(460, "커플 정보가 존재하지 않습니다"),
 	INVALID_ACCESS_TOKEN_EXCEPTION(480, "Access Token이 유효하지 않습니다."),
 	SERVER_EXCEPTION(500, "서버에서 예측하지 못한 에러가 발생했습니다.");
 

--- a/backend/src/main/java/com/ssafy/lovesol/global/exception/ExceptionController.java
+++ b/backend/src/main/java/com/ssafy/lovesol/global/exception/ExceptionController.java
@@ -25,6 +25,13 @@ public class ExceptionController {
 		return ResponseResult.exceptionResponse(ExceptionCode.NOT_EXIST_ACCOUNT_EXCEPTION);
 	}
 
+	@ExceptionHandler(NotExistAccountException.class)
+	public ResponseResult NotExistCoupleException(NotExistCoupleException err) {
+		log.info("Error : {}", err.getClass());
+		log.info("Error Message : {}", err.getMessage());
+		return ResponseResult.exceptionResponse(ExceptionCode.NOT_EXIST_COUPLE_EXCEPTION);
+	}
+
 	@ExceptionHandler(Exception.class)
 	public ResponseResult notExistDateLogException(Exception err) {
 		log.info("Error : {}", err.getClass());

--- a/backend/src/main/java/com/ssafy/lovesol/global/exception/NotExistCoupleException.java
+++ b/backend/src/main/java/com/ssafy/lovesol/global/exception/NotExistCoupleException.java
@@ -1,0 +1,11 @@
+package com.ssafy.lovesol.global.exception;
+
+public class NotExistCoupleException extends RuntimeException{
+    public NotExistCoupleException() {
+        super(ExceptionCode.NOT_EXIST_COUPLE_EXCEPTION.getErrorMessage());
+    }
+
+    public NotExistCoupleException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
1. 데이트 로그의 생성자를 세분화했습니다. (커플 객체와 데이트 날짜만 가지고 생성하도록 추가) 
2. 커플 Not Exist 예외 추가했습니다.
3. 데이트 로그 마일리지 적립 setter 메서드 생성했습니다.
4. 데이트 로그에 이미지를 삽입할 시, 클라이언트에서 데이트 로그와 이미지 URL 내용만으로 api 요청할 수 있게 request dto 생성했습니다.